### PR TITLE
feat: scaffold daemon components for KernelSU

### DIFF
--- a/apps/daemon/src/android_bridge.rs
+++ b/apps/daemon/src/android_bridge.rs
@@ -7,7 +7,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{RwLock, mpsc};
 use tokio_tungstenite::{accept_async, WebSocketStream};
 use tokio_tungstenite::tungstenite::Message;
-use futures_util::{SinkExt, StreamExt};
+use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::collections::HashMap;

--- a/apps/daemon/src/backup.rs
+++ b/apps/daemon/src/backup.rs
@@ -1,0 +1,40 @@
+use crate::android_bridge::BackupOptions;
+use crate::config::DaemonConfig;
+use crate::filesystem::FileSystemMonitor;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub struct BackupManager {
+    _config: Arc<DaemonConfig>,
+    _fs_monitor: Arc<RwLock<FileSystemMonitor>>,
+}
+
+impl BackupManager {
+    pub async fn new(config: &Arc<DaemonConfig>, fs_monitor: Arc<RwLock<FileSystemMonitor>>) -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {
+            _config: config.clone(),
+            _fs_monitor: fs_monitor,
+        })
+    }
+
+    pub async fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+
+    pub async fn start_backup(&self, _paths: Vec<String>, _options: BackupOptions) -> Result<String, Box<dyn std::error::Error>> {
+        Ok(uuid::Uuid::new_v4().to_string())
+    }
+
+    pub async fn get_active_job_count(&self) -> u32 {
+        0
+    }
+
+    pub async fn get_total_files_backed_up(&self) -> u64 {
+        0
+    }
+
+    pub async fn get_total_backup_size(&self) -> u64 {
+        0
+    }
+}
+

--- a/apps/daemon/src/filesystem.rs
+++ b/apps/daemon/src/filesystem.rs
@@ -1,0 +1,27 @@
+use crate::android_bridge::FileInfo;
+use crate::config::DaemonConfig;
+use crate::kernel_interface::KernelInterface;
+use std::sync::Arc;
+
+pub struct FileSystemMonitor {
+    _config: Arc<DaemonConfig>,
+    _kernel: Arc<KernelInterface>,
+}
+
+impl FileSystemMonitor {
+    pub async fn new(config: &Arc<DaemonConfig>, kernel: Arc<KernelInterface>) -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {
+            _config: config.clone(),
+            _kernel: kernel,
+        })
+    }
+
+    pub async fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+
+    pub async fn list_files(&self, _path: &str) -> Result<Vec<FileInfo>, Box<dyn std::error::Error>> {
+        Ok(Vec::new())
+    }
+}
+

--- a/apps/daemon/src/grpc_server.rs
+++ b/apps/daemon/src/grpc_server.rs
@@ -1,0 +1,26 @@
+use crate::android_bridge::AndroidBridge;
+use crate::backup::BackupManager;
+use crate::config::DaemonConfig;
+use crate::filesystem::FileSystemMonitor;
+use crate::kernel_interface::KernelInterface;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub struct GrpcServer;
+
+impl GrpcServer {
+    pub async fn new(
+        _config: &Arc<DaemonConfig>,
+        _backup: Arc<RwLock<BackupManager>>,
+        _fs: Arc<RwLock<FileSystemMonitor>>,
+        _android: Arc<AndroidBridge>,
+        _kernel: Arc<KernelInterface>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self)
+    }
+
+    pub async fn serve(&self) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+}
+

--- a/apps/daemon/src/kernel_interface.rs
+++ b/apps/daemon/src/kernel_interface.rs
@@ -1,0 +1,69 @@
+use crate::config::DaemonConfig;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::fs;
+use tokio::process::Command;
+use tracing::warn;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KernelStatus {
+    pub loaded: bool,
+    pub version: String,
+    pub features: Vec<String>,
+}
+
+pub struct KernelInterface {
+    config: Arc<DaemonConfig>,
+}
+
+impl KernelInterface {
+    pub async fn new(config: &Arc<DaemonConfig>) -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {
+            config: config.clone(),
+        })
+    }
+
+    pub async fn is_loaded(&self) -> bool {
+        fs::metadata("/proc/corestate").await.is_ok()
+    }
+
+    pub async fn load(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let module_path = self.config.kernel.module_path.clone();
+        let cmd = format!("insmod {}", module_path.display());
+        let status = Command::new("su").arg("-c").arg(&cmd).status().await;
+        if let Err(e) = status {
+            warn!("Failed to load kernel module: {}", e);
+        }
+        Ok(())
+    }
+
+    pub async fn unload(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let status = Command::new("su").arg("-c").arg("rmmod corestate").status().await;
+        if let Err(e) = status {
+            warn!("Failed to unload kernel module: {}", e);
+        }
+        Ok(())
+    }
+
+    pub async fn get_status(&self) -> KernelStatus {
+        let loaded = self.is_loaded().await;
+        let version = if loaded {
+            "2.0.0".to_string()
+        } else {
+            "unloaded".to_string()
+        };
+        let mut features = Vec::new();
+        if self.config.kernel.cow_enabled {
+            features.push("cow".to_string());
+        }
+        if self.config.kernel.snapshot_enabled {
+            features.push("snapshots".to_string());
+        }
+        KernelStatus {
+            loaded,
+            version,
+            features,
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add KernelInterface to manage KernelSU module status
- scaffold BackupManager, FileSystemMonitor, and GrpcServer
- fix Android bridge futures imports

## Testing
- `cargo test`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a5ab5c87883228382e53063f8b1f4